### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: ["main"]
 
+permissions:
+  contents: read
+
 jobs:
   install:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/fpezcara/book-tracker-ui/security/code-scanning/2](https://github.com/fpezcara/book-tracker-ui/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will explicitly limit the permissions of the `GITHUB_TOKEN` to `contents: read`, which is sufficient for the current workflow's operations. This ensures that the workflow adheres to the principle of least privilege and avoids granting unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
